### PR TITLE
chore: pin GitHub Actions and Docker images to digests

### DIFF
--- a/.github/actions/container-build/action.yml
+++ b/.github/actions/container-build/action.yml
@@ -30,10 +30,10 @@ runs:
   using: composite
   steps:
     - name: Set up Docker Build
-      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
     - name: Log in to Container Registry
-      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
+      uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4.5.2
       with:
         registry: ${{ inputs.registry }}
         username: ${{ inputs.registry-username }}
@@ -41,7 +41,7 @@ runs:
 
     - name: Extract metadata (tags, labels) for Docker
       id: meta
-      uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf  # v6.0.0
+      uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
       with:
         images: ${{ inputs.registry }}/${{ inputs.registry-path }}
         flavor: |
@@ -57,7 +57,7 @@ runs:
 
     - name: Build and push Docker image
       id: build
-      uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
+      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
       with:
         context: .
         file: ${{ inputs.dockerfile }}

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -27,7 +27,7 @@ jobs:
     outputs:
       digest: ${{ steps.image.outputs.digest }}
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: ./.github/actions/container-build
         id: image
@@ -45,7 +45,7 @@ jobs:
     outputs:
       digest: ${{ steps.image.outputs.digest }}
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: ./.github/actions/container-build
         id: image

--- a/DiscordBot/Dockerfile
+++ b/DiscordBot/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine@sha256:d8ee39817ca03a3757288e83c37ed73cc969a286c603b827c7cbe33add1c2d1c AS build
 WORKDIR /src
 
 # Copy only project files first for layer-cached restore.
@@ -13,7 +13,7 @@ COPY DiscordBot/ ./DiscordBot/
 RUN dotnet publish DiscordBot/DiscordBot.csproj -c Release -o /publish --no-restore
 
 
-FROM mcr.microsoft.com/dotnet/runtime:10.0-alpine
+FROM mcr.microsoft.com/dotnet/runtime:10.0-alpine@sha256:9297ae3050f7e80428142f784a6d016f80bc8b5cd54e7fc1b596935911b1e58e
 WORKDIR /app
 
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false

--- a/OpenShock.Activity.Api/Dockerfile
+++ b/OpenShock.Activity.Api/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine@sha256:d8ee39817ca03a3757288e83c37ed73cc969a286c603b827c7cbe33add1c2d1c AS build
 WORKDIR /src
 
 # Copy only project files first for layer-cached restore.
@@ -13,7 +13,7 @@ COPY OpenShock.Activity.Api/ ./OpenShock.Activity.Api/
 RUN dotnet publish OpenShock.Activity.Api/OpenShock.Activity.Api.csproj -c Release -o /app --no-restore
 
 
-FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine AS final-api
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine@sha256:27b6b84beeede74fd16886177d360799c8e4299ceadfbd64eef57bafead7878a AS final-api
 WORKDIR /app
 
 RUN apk add --no-cache openssl


### PR DESCRIPTION
Automated dependency pinning by the HeavenVR maintenance bot:

- GitHub Actions `uses:` refs upgraded to their latest release tag and pinned to the commit SHA that tag resolves to
- Dockerfile `FROM` images pinned to their current `@sha256` digest


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/OpenShock/DiscordBot/pull/76">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->